### PR TITLE
chore/bump-versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Unreleased
 
 - Fix an issue with the Enzyme choice, add README detail of testing library choice and fix some CI issues [#12](https://github.com/platanus/cavendish/pull/12)
+- Bump `expo-cli` and `@react-navigation` versions [#15](https://github.com/platanus/cavendish/pull/15)
 
 ### 0.1.0
 

--- a/lib/cavendish/assets/README.md.erb
+++ b/lib/cavendish/assets/README.md.erb
@@ -7,7 +7,7 @@ This is a React Native + Expo application, initially generated using [Cavendish]
 Assuming you've cloned the repo and that you have [Node](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/), the first thing you need to install is the Expo CLI:
 
 ```bash
-yarn global add expo-cli@4.8.x
+yarn global add expo-cli@<%= Cavendish::EXPO_CLI_VERSION %>
 ```
 
 Then install the project dependencies in your local machine:

--- a/lib/cavendish/version.rb
+++ b/lib/cavendish/version.rb
@@ -1,5 +1,5 @@
 module Cavendish
   VERSION = "0.1.0"
-  EXPO_CLI_VERSION = "4.8.x"
+  EXPO_CLI_VERSION = "4.12.x"
   REACT_NAVIGATION_VERSION = "5.x"
 end

--- a/lib/cavendish/version.rb
+++ b/lib/cavendish/version.rb
@@ -1,5 +1,5 @@
 module Cavendish
   VERSION = "0.1.0"
   EXPO_CLI_VERSION = "4.12.x"
-  REACT_NAVIGATION_VERSION = "5.x"
+  REACT_NAVIGATION_VERSION = "6.x"
 end


### PR DESCRIPTION
closes #13 
closes #14 

No other changes were needed because the Expo SDK didn't change (still in 42) and React Navigation major changes do not involve the initial setup of this generator