### PR TITLE
Chore/compatibility upgrade

### DIFF
--- a/lib/cavendish/commands/add_react_navigation.rb
+++ b/lib/cavendish/commands/add_react_navigation.rb
@@ -11,7 +11,7 @@ module Cavendish
 
       def install_dependencies
         run_in_project("yarn add #{react_navigation_core_dependencies.join(' ')}")
-        run_in_project("expo install #{react_navigation_side_dependencies.join(' ')}")
+        run_in_project("npx expo install #{react_navigation_side_dependencies.join(' ')}")
       end
 
       def add_example_navigator_and_screens

--- a/lib/cavendish/commands/create_expo_project.rb
+++ b/lib/cavendish/commands/create_expo_project.rb
@@ -13,7 +13,7 @@ module Cavendish
       end
 
       def create_expo_project
-        run("expo init #{config.project_name} --template blank")
+        run("npx create-expo-app #{config.project_name} --template blank")
       end
     end
   end

--- a/lib/cavendish/commands/create_expo_project.rb
+++ b/lib/cavendish/commands/create_expo_project.rb
@@ -8,7 +8,7 @@ module Cavendish
       private
 
       def create_expo_project
-        run("npx create-expo-app #{config.project_name} --template blank")
+        run("npx create-expo-app #{config.project_name} -t expo-template-blank-typescript")
       end
     end
   end

--- a/lib/cavendish/commands/create_expo_project.rb
+++ b/lib/cavendish/commands/create_expo_project.rb
@@ -2,15 +2,10 @@ module Cavendish
   module Commands
     class CreateExpoProject < Cavendish::Commands::Base
       def perform
-        install_expo_globally
         create_expo_project
       end
 
       private
-
-      def install_expo_globally
-        run("yarn global add expo-cli@#{Cavendish::EXPO_CLI_VERSION}")
-      end
 
       def create_expo_project
         run("npx create-expo-app #{config.project_name} --template blank")

--- a/lib/cavendish/version.rb
+++ b/lib/cavendish/version.rb
@@ -1,6 +1,5 @@
 module Cavendish
   VERSION = "0.1.0"
-  EXPO_CLI_VERSION = "4.12.x"
   REACT_NAVIGATION_VERSION = "6.x"
   TAILWIND_VERSION = "2.x"
 end


### PR DESCRIPTION
## Context
At Platanus we are aiming to resume the development of the cavendish gem.  On the roadmap ahead we are planning  to add typescript compatibility, and out of the box EAS configuration.

The first  step in that direction is to bump the versions of the packages used, and solve any compatibility issue that arises from that.

##  What has been done

-  Replaced the deprecated `expo init` for `npx create-expo-app`
-  Remove `EXPO_CLI_VERSION`  and global install of `expo-cli`
-  Change `expo install` to `npx expo install` (recommended since SDK 46)
-  Change expo template from Javascript to Typescript

## What's next
Update tailwind configuration. Update: done in #21 