### PR TITLE
Chore/tailwind config

### DIFF
--- a/lib/cavendish/assets/App.tsx
+++ b/lib/cavendish/assets/App.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 
+import AppProvider from './src/providers/AppProvider';
 import HomeNavigator from './src/navigators/HomeNavigator';
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <HomeNavigator />
-    </NavigationContainer>
+    <AppProvider>
+      <NavigationContainer>
+        <HomeNavigator />
+      </NavigationContainer>
+    </AppProvider>
   );
 }

--- a/lib/cavendish/assets/patches/tailwind-rn/tailwind-rn+4.2.0.patch
+++ b/lib/cavendish/assets/patches/tailwind-rn/tailwind-rn+4.2.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/tailwind-rn/dist/tailwind-provider.d.ts b/node_modules/tailwind-rn/dist/tailwind-provider.d.ts
+index afa56a7..5fdf130 100644
+--- a/node_modules/tailwind-rn/dist/tailwind-provider.d.ts
++++ b/node_modules/tailwind-rn/dist/tailwind-provider.d.ts
+@@ -4,6 +4,7 @@ import { Utilities } from './types';
+ interface Props {
+     utilities: Utilities;
+     colorScheme?: ColorSchemeName;
++    children: React.ReactNode;
+ }
+ declare const TailwindProvider: React.FC<Props>;
+ export default TailwindProvider;

--- a/lib/cavendish/assets/src/providers/AppProvider.tsx
+++ b/lib/cavendish/assets/src/providers/AppProvider.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { TailwindProvider, Utilities } from 'tailwind-rn';
+
+import utilities from '../../tailwind.json';
+
+export default function AppProvider({ children }: React.PropsWithChildren) {
+  return (
+    <TailwindProvider utilities={utilities as Utilities}>
+      {children}
+    </TailwindProvider>
+  ); 
+}

--- a/lib/cavendish/assets/src/screens/HomeScreen.jsx.erb
+++ b/lib/cavendish/assets/src/screens/HomeScreen.jsx.erb
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { View, Text } from 'react-native';
-
-import tailwind from '../utils/tailwindRn';
+import { useTailwind } from 'tailwind-rn';
 
 export default function HomeScreen() {
+  const tailwind = useTailwind();
   const [projectName] = useState('<%= @config.human_project_name %>');
 
   return (

--- a/lib/cavendish/assets/src/utils/tailwindRn.js
+++ b/lib/cavendish/assets/src/utils/tailwindRn.js
@@ -1,7 +1,0 @@
-import { create } from 'tailwind-rn';
-import styles from '../../styles.json';
-
-const { tailwind, getColor } = create(styles);
-
-export { getColor };
-export default tailwind;

--- a/lib/cavendish/assets/tailwind.config.js
+++ b/lib/cavendish/assets/tailwind.config.js
@@ -1,8 +1,11 @@
 module.exports = {
+  content: [
+    './src/**/*.{js,jsx,ts,tsx}',
+    'App.{js,jsx,ts,tsx}',
+  ],
   theme: {
     extend: {},
   },
-  variants: {
-    extend: {},
-  },
-};
+  plugins: [],
+  corePlugins: require('tailwind-rn/unsupported-core-plugins'),
+}

--- a/lib/cavendish/cli.rb
+++ b/lib/cavendish/cli.rb
@@ -37,7 +37,8 @@ module Cavendish
         Cavendish::Commands::AddTesting,
         Cavendish::Commands::AddCiConfig,
         Cavendish::Commands::AddReadme,
-        Cavendish::Commands::ConfigureGit
+        Cavendish::Commands::ConfigureGit,
+        Cavendish::Commands::AddTemplateFiles,
       ]
     end
 

--- a/lib/cavendish/cli.rb
+++ b/lib/cavendish/cli.rb
@@ -39,6 +39,7 @@ module Cavendish
         Cavendish::Commands::AddReadme,
         Cavendish::Commands::ConfigureGit,
         Cavendish::Commands::AddTemplateFiles,
+        Cavendish::Commands::PatchDependencies
       ]
     end
 

--- a/lib/cavendish/commands/add_tailwind.rb
+++ b/lib/cavendish/commands/add_tailwind.rb
@@ -19,14 +19,6 @@ module Cavendish
       def copy_tailwind_config_file
         copy_file('tailwind.config.js', 'tailwind.config.js')
       end
-
-      def generate_tailwind_rn_styles_json
-        run_in_project('yarn run create-tailwind-rn')
-      end
-
-      def copy_tailwind_utils
-        copy_file('src/utils/tailwindRn.js', 'src/utils/tailwindRn.js')
-      end
     end
   end
 end

--- a/lib/cavendish/commands/add_tailwind.rb
+++ b/lib/cavendish/commands/add_tailwind.rb
@@ -15,10 +15,6 @@ module Cavendish
       def run_setup_script
         run_in_project('npx setup-tailwind-rn')
       end
-
-      def copy_tailwind_config_file
-        copy_file('tailwind.config.js', 'tailwind.config.js')
-      end
     end
   end
 end

--- a/lib/cavendish/commands/add_tailwind.rb
+++ b/lib/cavendish/commands/add_tailwind.rb
@@ -3,16 +3,17 @@ module Cavendish
     class AddTailwind < Cavendish::Commands::Base
       def perform
         install_tailwind_rn_dependencies
-        copy_tailwind_config_file
-        generate_tailwind_rn_styles_json
-        copy_tailwind_utils
+        run_setup_script
       end
 
       private
 
       def install_tailwind_rn_dependencies
         run_in_project('yarn add tailwind-rn')
-        run_in_project("yarn add -D tailwindcss@#{Cavendish::TAILWIND_VERSION}")
+      end
+
+      def run_setup_script
+        run_in_project('npx setup-tailwind-rn')
       end
 
       def copy_tailwind_config_file

--- a/lib/cavendish/commands/add_template_files.rb
+++ b/lib/cavendish/commands/add_template_files.rb
@@ -1,0 +1,15 @@
+module Cavendish
+  module Commands
+    class AddTemplateFiles < Cavendish::Commands::Base
+      def perform
+        copy_tailwind_config_file
+      end
+
+      private
+
+      def copy_tailwind_config_file
+        copy_file('tailwind.config.js', 'tailwind.config.js')
+      end
+    end
+  end
+end

--- a/lib/cavendish/commands/add_template_files.rb
+++ b/lib/cavendish/commands/add_template_files.rb
@@ -3,12 +3,17 @@ module Cavendish
     class AddTemplateFiles < Cavendish::Commands::Base
       def perform
         copy_tailwind_config_file
+        copy_tailwind_provider_file
       end
 
       private
 
       def copy_tailwind_config_file
         copy_file('tailwind.config.js', 'tailwind.config.js')
+      end
+
+      def copy_tailwind_provider_file
+        copy_file('src/providers/AppProvider.tsx', 'src/providers/AppProvider.tsx')
       end
     end
   end

--- a/lib/cavendish/commands/patch_dependencies.rb
+++ b/lib/cavendish/commands/patch_dependencies.rb
@@ -1,7 +1,38 @@
 module Cavendish
   module Commands
     class PatchDependencies < Cavendish::Commands::Base
-      def perform; end
+      def perform
+        add_script_to_package
+        install_patch_package
+        create_patch_packages_files
+        run_in_project('yarn install')
+      end
+
+      PACKAGES_TO_PATCH = {
+        'tailwind-rn': 'tailwind-rn+4.2.0.patch'
+      }
+
+      private
+
+      def install_patch_package
+        run_in_project('yarn add patch-package postinstall-postinstall')
+      end
+
+      def add_script_to_package
+        inject_to_json_file('package.json', post_install_patch_package)
+      end
+
+      def create_patch_packages_files
+        PACKAGES_TO_PATCH.each do |package_name, filename|
+          copy_file("patches/#{package_name}/#{filename}", "patches/#{filename}")
+        end
+      end
+
+      def post_install_patch_package
+        {
+          scripts: { postinstall: "patch-package" }
+        }
+      end
     end
   end
 end

--- a/lib/cavendish/commands/patch_dependencies.rb
+++ b/lib/cavendish/commands/patch_dependencies.rb
@@ -1,0 +1,7 @@
+module Cavendish
+  module Commands
+    class PatchDependencies < Cavendish::Commands::Base
+      def perform; end
+    end
+  end
+end


### PR DESCRIPTION
# Context

Following the changes made in #20, this pull request tackles  the update of tailwind configuration, and a little refactoring in order to maintain a modular approach in the project.

# What has been done

Everything regarding tailwind installation, setup and configuration in the project.  In detail:
- call the new script `npx setup-tailwind-rn` that handles setup after installation
- remove tailwind utility files that are no longer necessary
- add `AppProvider` component that provides the `useTailwind` hook inside wrapped components
-  update tailwind configurarion file, specifying the path where the components using tailwind will be located. This accelerates tailwind compile time
- change main template to typescript and add `AppProvider` to it
- Update the call to `tailwind` variable. Now it is accesed through the `useTailwind` hook


Also,  two new commands have been created:
- `AddTemplateFiles`: handles file injections into the expo project
- `PatchDependencies`: this command patches `node_module` dependencies that could have conflicts (`tailwind-rn` had a type error conflict)

 