### PR TITLE
Feat/eas configuration

### DIFF
--- a/lib/cavendish/assets/app.config.ts.erb
+++ b/lib/cavendish/assets/app.config.ts.erb
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+import { ExpoConfig, ConfigContext } from 'expo/config'; 
+
+const { APP_ENV } = process.env;
+
+type AppEnvironment = 'development' | 'staging' | 'production';
+
+const appEnv = APP_ENV as AppEnvironment || 'development';
+
+const appEnvironmentConfig = {
+  development: {
+    name: '<%= @config.human_project_name %> Dev',
+    slug: '<%= @config.project_name %>-dev',
+  },
+  staging: {
+    name: '<%= @config.human_project_name %> Staging',
+    slug: '<%= @config.project_name %>-staging',
+  },
+  production: {
+    name: '<%= @config.human_project_name %>',
+    slug: '<%= @config.project_name %>',
+  },
+};
+
+const currentEnvironment = appEnvironmentConfig[appEnv];
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: currentEnvironment.name,
+  slug: currentEnvironment.slug,
+  android: {
+    ...config.android,
+    package: `com.${config.owner}.${currentEnvironment.slug}`,
+  },
+  ios: {
+    ...config.ios,
+    bundleIdentifier: `com.${config.owner}.${currentEnvironment.slug}`,
+  },
+});

--- a/lib/cavendish/cli.rb
+++ b/lib/cavendish/cli.rb
@@ -37,6 +37,7 @@ module Cavendish
         Cavendish::Commands::AddReactNavigation,
         Cavendish::Commands::AddTesting,
         Cavendish::Commands::AddCiConfig,
+        Cavendish::Commands::AddEASConfiguration,
         Cavendish::Commands::AddReadme,
         Cavendish::Commands::AddTemplateFiles,
         Cavendish::Commands::PatchDependencies,

--- a/lib/cavendish/commands/add_eas_configuration.rb
+++ b/lib/cavendish/commands/add_eas_configuration.rb
@@ -5,6 +5,7 @@ module Cavendish
         install_eas_cli
         register_and_create_organization_prompt
         login_to_expo
+        configure_project_owner
         set_basic_project_config
         inject_advanced_eas_config
       end
@@ -52,6 +53,10 @@ module Cavendish
 
       def login_to_expo
         run_in_project('eas login')
+      end
+
+      def configure_project_owner
+        run_in_project('eas project:init')
       end
 
       def set_basic_project_config

--- a/lib/cavendish/commands/add_eas_configuration.rb
+++ b/lib/cavendish/commands/add_eas_configuration.rb
@@ -1,0 +1,58 @@
+module Cavendish
+  module Commands
+    class AddEASConfiguration < Cavendish::Commands::Base
+      def perform
+        install_eas_cli
+        login_to_expo
+        set_basic_project_config
+        inject_advanced_eas_config
+      end
+
+      private
+
+      EAS_ADVANCED_CONFIG = {
+        build: {
+          development: {
+            channel: 'development'
+          },
+          staging: {
+            channel: 'staging',
+            android: {
+              buildType: 'apk'
+            },
+            env: {
+              APP_ENV: 'staging'
+            }
+          },
+          production: {
+            channel: 'production',
+            env: {
+              APP_ENV: 'production'
+            }
+          }
+        }
+      }
+
+      def install_eas_cli
+        run_in_project('npm install -g eas-cli')
+      end
+
+      def login_to_expo
+        run_in_project('eas login')
+      end
+
+      def set_basic_project_config
+        run_in_project('eas build:configure')
+      end
+
+      def inject_advanced_eas_config
+        rename_preview_to_staging
+        inject_to_json_file('eas.json', EAS_ADVANCED_CONFIG)
+      end
+
+      def rename_preview_to_staging
+        rename_key_in_json('eas.json', 'build.preview', 'staging')
+      end
+    end
+  end
+end

--- a/lib/cavendish/commands/add_eas_configuration.rb
+++ b/lib/cavendish/commands/add_eas_configuration.rb
@@ -3,12 +3,20 @@ module Cavendish
     class AddEASConfiguration < Cavendish::Commands::Base
       def perform
         install_eas_cli
+        register_and_create_organization_prompt
         login_to_expo
         set_basic_project_config
         inject_advanced_eas_config
       end
 
       private
+
+      REGISTER_MESSAGE = <<~MSG
+        To configure Expo Application Services (EAS) into your app, it is necessary to have an expo account. Please register at https://expo.dev/signup if you don't have an account (enter to continue).
+      MSG
+      CREATE_ORGANIZATION_MESSAGE = <<~MSG
+        If you are planning to collaborate with others in this project, it is adviced to create an organization. Create an organization at https://expo.dev/create-organization (enter to continue)
+      MSG
 
       EAS_ADVANCED_CONFIG = {
         build: {
@@ -35,6 +43,11 @@ module Cavendish
 
       def install_eas_cli
         run_in_project('npm install -g eas-cli')
+      end
+
+      def register_and_create_organization_prompt
+        ask(REGISTER_MESSAGE)
+        ask(CREATE_ORGANIZATION_MESSAGE)
       end
 
       def login_to_expo

--- a/lib/cavendish/commands/add_template_files.rb
+++ b/lib/cavendish/commands/add_template_files.rb
@@ -7,6 +7,7 @@ module Cavendish
         copy_sample_navigator_and_screens
         replace_app_entrypoint
         copy_test_files
+        copy_app_config
       end
 
       private
@@ -36,6 +37,10 @@ module Cavendish
         )
         copy_file('__mocks__/tailwind-rn.ts', '__mocks__/tailwind-rn.ts')
         copy_file('__mocks__/@react-navigation/native.ts', '__mocks__/@react-navigation/native.ts')
+      end
+
+      def copy_app_config
+        copy_template('app.config.ts', 'app.config.ts')
       end
     end
   end

--- a/lib/cavendish/utils.rb
+++ b/lib/cavendish/utils.rb
@@ -58,6 +58,27 @@ module Cavendish
       File.open(path, "wb") { |file| file.write(content) }
     end
 
+    def rename_key_in_json(file_path, key_path, new_key_name)
+      package_path = File.join(project_root_path, file_path)
+      json_obj = JSON.parse(File.read(package_path))
+
+      keys = key_path.split('.')
+      current_obj = json_obj
+      keys.each_with_index do |key, index|
+        if current_obj[key].nil?
+          raise "Key '#{key}' not found in JSON object"
+        end
+
+        if index == keys.length - 1
+          current_obj[new_key_name] = current_obj.delete(key)
+        else
+          current_obj = current_obj[key]
+        end
+      end
+
+      File.write(package_path, JSON.pretty_generate(json_obj))
+    end
+
     def get_or_generate_destination_path(destination)
       destination_path = File.join(project_root_path, destination)
       ::FileUtils.mkdir_p(File.dirname(destination_path))


### PR DESCRIPTION
# Context
Expo provides services to build remotely  and deploy apps easily to the stores via [Expo Application Services](https://expo.dev/eas) (EAS). In order to use this service, certain files in expo projects must be configured.
# What has been done
A new command has been added that does the setup needed to configure EAS and links the project to [expo.dev](https://expo.dev/).
In detail:
-  added a utility function to rename a key in a json file
-  initial eas configuration and project link to expo.dev, and `eas.json` configuration
- add prompts to alert to the user running the gem that he needs an expo account, and that he should create an organization to handle the project
-  add `eas project:init` command that asks the user to select in which organization the project should be in
- add eas command to the cli flow
-  add template for app configuration file that changes it's name and app id depending on the environment of the application