### PR TITLE
Chore/eslint

### DIFF
--- a/lib/cavendish/assets/.eslintrc.json
+++ b/lib/cavendish/assets/.eslintrc.json
@@ -1,43 +1,52 @@
 {
   "env": {
-    "es6": true,
-    "jest": true
+    "browser": true,
+    "es2021": true
   },
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "plugin:react/recommended",
+    "plugin:react/jsx-runtime"
+  ],
   "globals": {
-    "Atomics": "readonly",
-    "SharedArrayBuffer": "readonly",
     "jest": true
   },
-  "parser": "babel-eslint",
+  "overrides": [],
   "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": 2018,
+    "project": "./tsconfig.json",
+    "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react"],
+  "plugins": [
+    "react"
+  ],
   "rules": {
-    "no-console": 2,
-    "react/prop-types": ["error", { "ignore": ["route", "navigation"] }],
-    "react/jsx-first-prop-new-line": [1, "multiline"],
-    "react/jsx-max-props-per-line": [1, { "maximum": 1 }],
+    "no-console": "warn",
     "react/jsx-one-expression-per-line": "off",
-    "global-require": "off",
     "import/prefer-default-export": "off",
-    "import/no-extraneous-dependencies": [
+    "react/jsx-props-no-spreading": "off",
+    "react/jsx-filename-extension": [
       "error",
-      { "devDependencies": ["**/*.spec.js", "src/factories/**"] }
-    ],
-    "react/jsx-filename-extension": [1, { "extensions": [".spec.js", ".jsx"] }],
-    "react/jsx-props-no-spreading": 0
-  },
-  "settings": {
-    "import/resolver": {
-      "alias": {
-        "extensions": [".js", ".jsx"]
+      {
+        "extensions": [".spec.js", ".jsx", ".spec.ts", ".tsx"]
       }
-    }
+    ],
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          ["builtin", "external"],
+          "internal",
+          ["parent", "sibling"],
+          "index"
+        ],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc"
+        }
+      }
+    ]
   }
 }

--- a/lib/cavendish/commands/add_eslint.rb
+++ b/lib/cavendish/commands/add_eslint.rb
@@ -2,8 +2,9 @@ module Cavendish
   module Commands
     class AddEslint < Cavendish::Commands::Base
       def perform
+        install_airbnb_eslint
+        install_typescript_eslint_dependencies
         copy_config_file
-        install_eslint_dependencies
       end
 
       private
@@ -12,20 +13,19 @@ module Cavendish
         copy_file(".eslintrc.json", ".eslintrc.json")
       end
 
-      def install_eslint_dependencies
+      def install_airbnb_eslint
+        run_in_project('npx install-peerdeps --dev eslint-config-airbnb --yarn')
+      end
+
+      def install_typescript_eslint_dependencies
         run_in_project("yarn add -D #{eslint_dependencies.join(' ')}")
       end
 
       def eslint_dependencies
         %w[
-          babel-eslint
-          eslint
-          eslint-config-airbnb
-          eslint-import-resolver-alias
-          eslint-plugin-import
-          eslint-plugin-jsx-a11y
-          eslint-plugin-react
-          eslint-plugin-react-hooks
+          eslint-config-airbnb-typescript
+          @typescript-eslint/eslint-plugin@^5.13.0
+          @typescript-eslint/parser@^5.0.0
         ]
       end
     end


### PR DESCRIPTION
# Context
Cavendish has been unsupported for a year, but now we intend to empower mobile development in Platanus and we see this generator as the center of best practices adopted within the company.

In order to accomplish this, first we have to update the core dependencies.

# What's been done
I updated the ESLint configurations to match the changes from Javascript to Typescript.

Some rules were inspired by the [`triciclos-mobile` settings](https://github.com/platanus/triciclos-mobile/blob/main/.eslintrc.json) (which were inspired by the Buda.com app), but if there are any that you consider useful from `duit-mobile`, I'll happily add them (@MatiasMontagna).