### PR TITLE
Chore/aliases

### DIFF
--- a/lib/cavendish/assets/App.tsx
+++ b/lib/cavendish/assets/App.tsx
@@ -1,5 +1,5 @@
-import AppProvider from './src/providers/AppProvider';
-import HomeNavigator from './src/navigators/HomeNavigator';
+import AppProvider from '@/providers/AppProvider';
+import HomeNavigator from '@/navigators/HomeNavigator';
 
 export default function App() {
   return (

--- a/lib/cavendish/assets/src/navigators/HomeNavigator.tsx
+++ b/lib/cavendish/assets/src/navigators/HomeNavigator.tsx
@@ -1,6 +1,6 @@
 import { createStackNavigator } from '@react-navigation/stack';
 
-import HomeScreen from '../screens/HomeScreen';
+import HomeScreen from '@/screens/HomeScreen';
 
 const Stack = createStackNavigator();
 

--- a/lib/cavendish/cli.rb
+++ b/lib/cavendish/cli.rb
@@ -32,8 +32,9 @@ module Cavendish
       [
         Cavendish::Commands::CreateExpoProject,
         Cavendish::Commands::AddTailwind,
-        Cavendish::Commands::AddReactNavigation,
         Cavendish::Commands::AddEslint,
+        Cavendish::Commands::AddAliasSupport,
+        Cavendish::Commands::AddReactNavigation,
         Cavendish::Commands::AddTesting,
         Cavendish::Commands::AddCiConfig,
         Cavendish::Commands::AddReadme,

--- a/lib/cavendish/commands/add_alias_support.rb
+++ b/lib/cavendish/commands/add_alias_support.rb
@@ -1,0 +1,29 @@
+module Cavendish
+  module Commands
+    class AddAliasSupport < Cavendish::Commands::Base
+      ALIASES = {
+        "@": "src",
+        "assets": "assets"
+      }
+
+      def perform
+        add_typescript_settings
+      end
+
+      private
+
+      def add_typescript_settings
+        inject_to_json_file('tsconfig.json', typescript_settings)
+      end
+
+      def typescript_settings
+        {
+          compilerOptions: {
+            baseUrl: ".",
+            paths: ALIASES.map { |from, to| { "#{from}/*": ["#{to}/*"] } }.inject(:merge)
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/cavendish/commands/add_alias_support.rb
+++ b/lib/cavendish/commands/add_alias_support.rb
@@ -8,6 +8,8 @@ module Cavendish
 
       def perform
         add_typescript_settings
+        install_eslint_dependencies
+        add_eslint_settings
       end
 
       private
@@ -16,11 +18,29 @@ module Cavendish
         inject_to_json_file('tsconfig.json', typescript_settings)
       end
 
+      def install_eslint_dependencies
+        run_in_project("yarn add -D eslint-import-resolver-typescript")
+      end
+
+      def add_eslint_settings
+        inject_to_json_file('.eslintrc.json', eslint_settings)
+      end
+
       def typescript_settings
         {
           compilerOptions: {
             baseUrl: ".",
             paths: ALIASES.map { |from, to| { "#{from}/*": ["#{to}/*"] } }.inject(:merge)
+          }
+        }
+      end
+
+      def eslint_settings
+        {
+          settings: {
+            "import/resolver": {
+              typescript: {}
+            }
           }
         }
       end

--- a/lib/cavendish/commands/add_alias_support.rb
+++ b/lib/cavendish/commands/add_alias_support.rb
@@ -10,6 +10,7 @@ module Cavendish
         add_typescript_settings
         install_eslint_dependencies
         add_eslint_settings
+        add_babel_settings
       end
 
       private
@@ -24,6 +25,10 @@ module Cavendish
 
       def add_eslint_settings
         inject_to_json_file('.eslintrc.json', eslint_settings)
+      end
+
+      def add_babel_settings
+        gsub_file('babel.config.js', "presets: ['babel-preset-expo'],", babel_settings)
       end
 
       def typescript_settings
@@ -43,6 +48,21 @@ module Cavendish
             }
           }
         }
+      end
+
+      def babel_settings
+        <<~BABEL.strip
+          presets: ['babel-preset-expo'],
+          plugins: [
+            ['module-resolver', {
+              alias: {
+                #{ALIASES.map { |from, to| "'#{from}': `${__dirname}/#{to}`" }.join(
+                  ",\n\t\t\t\t\t"
+                )}
+              },
+            }],
+          ],
+        BABEL
       end
     end
   end

--- a/lib/cavendish/utils.rb
+++ b/lib/cavendish/utils.rb
@@ -1,5 +1,12 @@
 module Cavendish
   module Utils
+    def gsub_file(in_project_path, flag, *args, &block)
+      path = File.join(project_root_path, in_project_path)
+      content = File.binread(path)
+      content.gsub!(flag, *args, &block)
+      File.open(path, "wb") { |file| file.write(content) }
+    end
+
     def copy_file(source, destination)
       log 'CREATE', destination
       ::FileUtils.cp(get_template_path(source), get_or_generate_destination_path(destination))


### PR DESCRIPTION
# Context
Cavendish has been unsupported for a year, but now we intend to empower mobile development in Platanus and we see this generator as the center of best practices adopted within the company.

In order to accomplish this, first we have to update the core dependencies.

# What's been done
I added support for aliases, with `@` pointing to `/src` and with `assets` pointing to `/assets` (any suggestions within the name is welcome, maybe `src` is better from `/src`?).

The configuration is extendable if we find convenient to add a third alias, just by modifying the `Cavendish::AddAliasSupport::ALIASES` constant.