### PR TITLE
Fix/misc setup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ Use the `cavendish create` command to create a new project:
 
     $ cavendish create <project-name>
 
-This command will ask for your preferences on some packages and generate a full React Native + Expo project with:
+This command will generate a full React Native + Expo project with:
 
 - ESLint
-- Testing with Jest (either with `@testing-library/react-native` or `enzyme`)
+- Testing with Jest and `@testing-library/react-native`
 - A base `@react-navigation` config for navigation and screens
 - A base `tailwind-rn` for managing styles
+- A base configuration of Expo Application Services (EAS)
 - CI configuration for CircleCI
 - An initialized Git repository
 
-The generator uses the `expo-cli` to generate a blank managed workflow project. *Bare workflow* projects are not supported for now.
+The generator uses the `expo-cli` to generate a typescript blank managed workflow project. *Bare workflow* projects are not supported for now.
 
 ## Testing
 

--- a/lib/cavendish/assets/.eslintrc.json
+++ b/lib/cavendish/assets/.eslintrc.json
@@ -33,6 +33,12 @@
         "extensions": [".spec.js", ".jsx", ".spec.ts", ".tsx"]
       }
     ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": ["../*"]
+      }
+    ],
     "import/order": [
       "error",
       {

--- a/lib/cavendish/assets/App.tsx
+++ b/lib/cavendish/assets/App.tsx
@@ -1,5 +1,5 @@
-import AppProvider from '@/providers/AppProvider';
 import HomeNavigator from '@/navigators/HomeNavigator';
+import AppProvider from '@/providers/AppProvider';
 
 export default function App() {
   return (

--- a/lib/cavendish/assets/app.config.ts.erb
+++ b/lib/cavendish/assets/app.config.ts.erb
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { ExpoConfig, ConfigContext } from 'expo/config'; 
+import { ExpoConfig, ConfigContext } from 'expo/config';
 
 const { APP_ENV } = process.env;
 
@@ -7,18 +7,26 @@ type AppEnvironment = 'development' | 'staging' | 'production';
 
 const appEnv = APP_ENV as AppEnvironment || 'development';
 
+const APP_NAME = '<%= @config.human_project_name %>';
+const APP_SLUG = '<%= @config.project_name %>';
+const ANDROID_IDENTIFIER = APP_SLUG.replace(/-/g, '_');
+const IOS_IDENTIFIER = APP_SLUG;
+
 const appEnvironmentConfig = {
   development: {
-    name: '<%= @config.human_project_name %> Dev',
-    slug: '<%= @config.project_name %>-dev',
+    name: `${APP_NAME} Dev`,
+    androidIdentifier: `${ANDROID_IDENTIFIER}_dev`,
+    iosIdentifier: `${IOS_IDENTIFIER}-dev`,
   },
   staging: {
-    name: '<%= @config.human_project_name %> Staging',
-    slug: '<%= @config.project_name %>-staging',
+    name: `${APP_NAME} Staging`,
+    androidIdentifier: `${ANDROID_IDENTIFIER}_staging`,
+    iosIdentifier: `${IOS_IDENTIFIER}-staging`,
   },
   production: {
-    name: '<%= @config.human_project_name %>',
-    slug: '<%= @config.project_name %>',
+    name: APP_NAME,
+    androidIdentifier: ANDROID_IDENTIFIER,
+    iosIdentifier: IOS_IDENTIFIER,
   },
 };
 
@@ -27,13 +35,13 @@ const currentEnvironment = appEnvironmentConfig[appEnv];
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: currentEnvironment.name,
-  slug: currentEnvironment.slug,
+  slug: APP_SLUG,
   android: {
     ...config.android,
-    package: `com.${config.owner}.${currentEnvironment.slug}`,
+    package: `com.${config.owner}.${currentEnvironment.androidIdentifier}`,
   },
   ios: {
     ...config.ios,
-    bundleIdentifier: `com.${config.owner}.${currentEnvironment.slug}`,
+    bundleIdentifier: `com.${config.owner}.${currentEnvironment.iosIdentifier}`,
   },
 });

--- a/lib/cavendish/assets/babel.config.js
+++ b/lib/cavendish/assets/babel.config.js
@@ -1,0 +1,15 @@
+module.exports = (api) => {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      ['module-resolver', {
+        alias: {
+          '@': `${__dirname}/src`,
+          assets: `${__dirname}/assets`,
+        },
+        extensions: ['.js', '.ts', '.json', '.jsx', '.tsx', '.d.ts'],
+      }],
+    ],
+  };
+};

--- a/lib/cavendish/assets/src/providers/AppProvider.tsx
+++ b/lib/cavendish/assets/src/providers/AppProvider.tsx
@@ -1,6 +1,7 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { TailwindProvider, Utilities } from 'tailwind-rn';
 
+// eslint-disable-next-line no-restricted-imports
 import utilities from '../../tailwind.json';
 
 export default function AppProvider({ children }: React.PropsWithChildren) {

--- a/lib/cavendish/assets/src/screens/__specs__/HomeScreen.spec.tsx.erb
+++ b/lib/cavendish/assets/src/screens/__specs__/HomeScreen.spec.tsx.erb
@@ -2,8 +2,9 @@ import { render } from '@testing-library/react-native';
 import { Factory } from 'fishery';
 
 import HomeScreen from '../HomeScreen';
+import type { User } from '@/types/user';
 
-const userFactory = Factory.define<{ id: number; name: string; }>(({ sequence }) => ({
+const userFactory = Factory.define<User>(({ sequence }) => ({
   id: sequence,
   name: 'John Doe',
   company: '<%= @config.human_project_name %>',

--- a/lib/cavendish/assets/src/screens/__specs__/HomeScreen.spec.tsx.erb
+++ b/lib/cavendish/assets/src/screens/__specs__/HomeScreen.spec.tsx.erb
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react-native';
 import { Factory } from 'fishery';
 
-import HomeScreen from '../HomeScreen';
+import HomeScreen from '@/screens/HomeScreen';
 import type { User } from '@/types/user';
 
 const userFactory = Factory.define<User>(({ sequence }) => ({
@@ -23,7 +23,7 @@ describe('HomeScreen specs', () => {
   });
 
   it('has a valid factory', () => {
-    const user = userFactory.build()
+    const user = userFactory.build();
     expect(user.name).toEqual('John Doe');
     expect(user.company).toEqual('<%= @config.human_project_name %>');
   });

--- a/lib/cavendish/assets/src/types/user.d.ts
+++ b/lib/cavendish/assets/src/types/user.d.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: number;
+  name: string;
+  company: string;
+}

--- a/lib/cavendish/assets/tailwind.config.js
+++ b/lib/cavendish/assets/tailwind.config.js
@@ -7,5 +7,6 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  // eslint-disable-next-line global-require
   corePlugins: require('tailwind-rn/unsupported-core-plugins'),
-}
+};

--- a/lib/cavendish/cli.rb
+++ b/lib/cavendish/cli.rb
@@ -41,6 +41,7 @@ module Cavendish
         Cavendish::Commands::AddReadme,
         Cavendish::Commands::AddTemplateFiles,
         Cavendish::Commands::PatchDependencies,
+        Cavendish::Commands::Cleanup,
         Cavendish::Commands::ConfigureGit
       ]
     end

--- a/lib/cavendish/commands/add_eas_configuration.rb
+++ b/lib/cavendish/commands/add_eas_configuration.rb
@@ -8,6 +8,7 @@ module Cavendish
         configure_project_owner
         set_basic_project_config
         inject_advanced_eas_config
+        configure_eas_update
       end
 
       private
@@ -61,6 +62,10 @@ module Cavendish
 
       def set_basic_project_config
         run_in_project('eas build:configure')
+      end
+
+      def configure_eas_update
+        run_in_project('eas update:configure')
       end
 
       def inject_advanced_eas_config

--- a/lib/cavendish/commands/add_tailwind.rb
+++ b/lib/cavendish/commands/add_tailwind.rb
@@ -26,7 +26,6 @@ module Cavendish
 
           # tailwind-rn
           tailwind.css
-          tailwind.json
         GITIGNORE
       end
     end

--- a/lib/cavendish/commands/add_template_files.rb
+++ b/lib/cavendish/commands/add_template_files.rb
@@ -7,7 +7,9 @@ module Cavendish
         copy_sample_navigator_and_screens
         replace_app_entrypoint
         copy_test_files
+        copy_type_files
         copy_app_config
+        replace_babel_config
       end
 
       private
@@ -45,6 +47,11 @@ module Cavendish
 
       def copy_app_config
         copy_template('app.config.ts', 'app.config.ts')
+      end
+
+      def replace_babel_config
+        remove_in_project('babel.config.js')
+        copy_file('babel.config.js', 'babel.config.js')
       end
     end
   end

--- a/lib/cavendish/commands/add_template_files.rb
+++ b/lib/cavendish/commands/add_template_files.rb
@@ -25,6 +25,10 @@ module Cavendish
         copy_file('src/navigators/HomeNavigator.tsx', 'src/navigators/HomeNavigator.tsx')
       end
 
+      def copy_type_files
+        copy_file('src/types/user.d.ts', 'src/types/user.d.ts')
+      end
+
       def replace_app_entrypoint
         remove_in_project('App.tsx')
         copy_file('App.tsx', 'App.tsx')

--- a/lib/cavendish/commands/cleanup.rb
+++ b/lib/cavendish/commands/cleanup.rb
@@ -1,0 +1,18 @@
+module Cavendish
+  module Commands
+    class Cleanup < Cavendish::Commands::Base
+      def perform
+        lint_generated_files
+        delete_npm_lock
+      end
+
+      def lint_generated_files
+        run_in_project('yarn eslint . --fix')
+      end
+
+      def delete_npm_lock
+        remove_in_project('package-lock.json')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

Cavendish is a mobile project generator. It was recently used to generate a new project and it worked great for most of its purposes. However, there were some aspects that were not configured or consistent throughout the project that were detected.

# What has been done

This PR addresses miscellaneous setup errors that were found when using cavendish on a new project.
Also, it adds two desired things in mobile projects: a `types` folder and a `no-relative-imports` linter rule.

 In detail, commit by commit:
- Configure `eas update`. Without this step, `Updates.channel` was always undefined
- Don't put `tailwind.json` in `.gitignore`. All files that are in the `.gitignore` will not be avalaible for eas on the build process and if `tailwind.json` is not available it will cause the build to fail
- Add `types` folder
- Add rule that forbids the pattern `../` on imports
- Fix lint problems that were on template files
- Differentiate ios and android configuration. This had to be done because android supports underscores (`_`) and ios supports hyphens (`-`)
-  Add a custom babel configuration. This had to be done in order to add the line `extensions: ['.js', '.ts', '.json', '.jsx', '.tsx', '.d.ts'],` 
- Add the `Cleanup` command that will handle all the cleanup needed. Now it lints all the generated project  files and then deletes the `package-lock.json` file to only use `yarn.lock`
- The user now can´t choose the configuration of cavendish, so the README is updated to be consistent