### PR TITLE
Redux Basic Setup

### DIFF
--- a/lib/cavendish/assets/.eslintrc.json
+++ b/lib/cavendish/assets/.eslintrc.json
@@ -33,10 +33,19 @@
         "extensions": [".spec.js", ".jsx", ".spec.ts", ".tsx"]
       }
     ],
+    "no-param-reassign": 0,
     "no-restricted-imports": [
       "error",
       {
         "patterns": ["../*"]
+      }
+    ],
+    "@typescript-eslint/no-restricted-imports":[
+      "error",
+      {
+        "name": "react-redux",
+        "importNames": ["useSelector", "useDispatch"],
+        "message": "Use typed hooks `useAppDispatch` and `useAppSelector` instead."
       }
     ],
     "import/order": [

--- a/lib/cavendish/assets/src/store/hooks.ts
+++ b/lib/cavendish/assets/src/store/hooks.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+import type { RootState, AppDispatch } from '@/store';
+
+type DispatchFunc = () => AppDispatch;
+
+export const useAppDispatch: DispatchFunc = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/lib/cavendish/assets/src/store/index.ts
+++ b/lib/cavendish/assets/src/store/index.ts
@@ -1,0 +1,14 @@
+import { configureStore } from '@reduxjs/toolkit';
+import thunk from 'redux-thunk';
+
+import appReducer from '@/store/reducers';
+
+const store = configureStore({
+  reducer: appReducer,
+  middleware: [thunk],
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/lib/cavendish/assets/src/store/reducers.ts
+++ b/lib/cavendish/assets/src/store/reducers.ts
@@ -1,0 +1,5 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+const appReducer = combineReducers({});
+
+export default appReducer;

--- a/lib/cavendish/assets/src/store/reducers.ts
+++ b/lib/cavendish/assets/src/store/reducers.ts
@@ -3,3 +3,43 @@ import { combineReducers } from '@reduxjs/toolkit';
 const appReducer = combineReducers({});
 
 export default appReducer;
+
+/*
+// Example on how to create a counter slice in the path `src/store/slices/counter.ts`
+
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+const initialState = {
+  value: 0,
+};
+
+export const counterSlice = createSlice({
+  name: 'counter',
+  initialState,
+  reducers: {
+    reset(state) {
+      state.value = 0;
+    },
+    incrementBy(state, action: PayloadAction<number>) {
+      state.value += action.payload;
+    },
+    decrementBy(state, action: PayloadAction<number>) {
+      state.value -= action.payload;
+    },
+  },
+});
+
+
+// then to connect the slice, in this file do
+
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { counterSlice } from @/store/slices/counter;
+
+const appReducer = combineReducers({
+  counter: counterSlice.reducer,
+});
+
+export default appReducer;
+
+*/

--- a/lib/cavendish/cli.rb
+++ b/lib/cavendish/cli.rb
@@ -35,6 +35,7 @@ module Cavendish
         Cavendish::Commands::AddEslint,
         Cavendish::Commands::AddAliasSupport,
         Cavendish::Commands::AddReactNavigation,
+        Cavendish::Commands::AddRedux,
         Cavendish::Commands::AddTesting,
         Cavendish::Commands::AddCiConfig,
         Cavendish::Commands::AddEASConfiguration,

--- a/lib/cavendish/commands/add_redux.rb
+++ b/lib/cavendish/commands/add_redux.rb
@@ -1,0 +1,23 @@
+module Cavendish
+  module Commands
+    class AddRedux < Cavendish::Commands::Base
+      def perform
+        install_dependencies
+      end
+
+      private
+
+      def install_dependencies
+        run_in_project("yarn add #{redux_dependencies.join(' ')}")
+      end
+
+      def redux_dependencies
+        %w[
+          @reduxjs/toolkit
+          react-redux
+          redux-thunk
+        ]
+      end
+    end
+  end
+end

--- a/lib/cavendish/commands/add_template_files.rb
+++ b/lib/cavendish/commands/add_template_files.rb
@@ -10,6 +10,7 @@ module Cavendish
         copy_type_files
         copy_app_config
         replace_babel_config
+        copy_redux_setup_files
       end
 
       private
@@ -52,6 +53,12 @@ module Cavendish
       def replace_babel_config
         remove_in_project('babel.config.js')
         copy_file('babel.config.js', 'babel.config.js')
+      end
+
+      def copy_redux_setup_files
+        copy_file('src/store/index.ts', 'src/store/index.ts')
+        copy_file('src/store/hooks.ts', 'src/store/hooks.ts')
+        copy_file('src/store/reducers.ts', 'src/store/reducers.ts')
       end
     end
   end


### PR DESCRIPTION
# Context

Cavendish didn't had an state management framework coupled yet. 

At Platanus we have decided to go with `redux` for state management and `redux-thunk`  to handle the side effects.

# What has been done

Now, the projects generated with cavendish have a basic redux setup,  and a typed `useAppDispatch` and `useAppSelector` hook.

In detail: 
- The new command `AddRedux` is created to handle redux package dependencies
- Redux setup files are added. The file `hooks.ts` adds type to the `useDispatch` and `useSelector`  hooks. This is useful because now it won't be needed to specify the type of those hooks on every call.
-  Add an eslint rule to allow reassigns (to reassign state when creating slices) and a rule to forbid `useDispatch` and `useSelector` imports in order to force the use of the typed hooks `useAppSelector` and `useAppDispatch`