### PR TITLE
fix(app-provider): add redux provider

### DIFF
--- a/lib/cavendish/assets/src/providers/AppProvider.tsx
+++ b/lib/cavendish/assets/src/providers/AppProvider.tsx
@@ -1,5 +1,8 @@
 import { NavigationContainer } from '@react-navigation/native';
+import { Provider as ReduxProvider } from 'react-redux';
 import { TailwindProvider, Utilities } from 'tailwind-rn';
+
+import { store } from '@/store';
 
 // eslint-disable-next-line no-restricted-imports
 import utilities from '../../tailwind.json';
@@ -8,7 +11,9 @@ export default function AppProvider({ children }: React.PropsWithChildren) {
   return (
     <NavigationContainer>
       <TailwindProvider utilities={utilities as Utilities}>
-        {children}
+        <ReduxProvider store={store}>
+          {children}
+        </ReduxProvider>
       </TailwindProvider>
     </NavigationContainer>
   );


### PR DESCRIPTION
# Context
In #28, the basic redux setup was added, but it missed the redux provider setup.
# What has been done
Add `ReduxProvider` to `AppProvider`, so that the app has access to the store.
